### PR TITLE
Allow hot param to be overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ By defaults:
 | `devServer.host` | `0.0.0.0` |
 | `devServer.port` | `8080` |
 | `devServer.watchContentBase` | `true` |
-
+| `devServer.hot` | `true` |
 
 If you want to customize `devServer` options, modify `webpack.config.js` file as follows:
 

--- a/src/webpackServe.ts
+++ b/src/webpackServe.ts
@@ -103,8 +103,8 @@ module.exports = (ctx: any) =>
       host: defaultHost,
       port,
       watchContentBase: true,
-      ...customDevServerConfig,
       hot: true,
+      ...customDevServerConfig,
       before: (app, server) => {
         if (customDevServerConfig.before)
           customDevServerConfig.before(app, server);

--- a/src/webpackServe.ts
+++ b/src/webpackServe.ts
@@ -117,7 +117,7 @@ module.exports = (ctx: any) =>
     };
 
     // HMR
-    WebpackDevServer.addDevServerEntrypoints(webpackConfig, devServerConfig);
+    if(devServerConfig.hot) WebpackDevServer.addDevServerEntrypoints(webpackConfig, devServerConfig);
 
     const compiler = webpack(webpackConfig);
     const server = new WebpackDevServer(compiler, devServerConfig);


### PR DESCRIPTION
Currently, the `hot` parameter isn't being respected from the users custom `devServer` config. This fix will still keep the `hot` parameter defaulted to `true`, but allow the user to overwrite it if they want page reloading instead of hot module reloading.

Fixes #7