### PR TITLE
refactor: remove is-ua-webview type

### DIFF
--- a/typings/is-ua-webview/index.d.ts
+++ b/typings/is-ua-webview/index.d.ts
@@ -1,2 +1,0 @@
-declare function isWebview(ua: string): boolean;
-export default isWebview;


### PR DESCRIPTION
This PR (https://github.com/atomantic/is-ua-webview/pull/3) is included in is-ua-webview v1.0.2
I removed is-ua-webview type defined myself because this PR was published to npm.