### PR TITLE
Use absolute path to cordova script

### DIFF
--- a/src/www/injectCordovaScript.ts
+++ b/src/www/injectCordovaScript.ts
@@ -10,7 +10,7 @@ const injectCordovaScript = (platform: typeof platforms[number]) => {
 
   const scriptEl = document.createElement('script');
   scriptEl.setAttribute('type', 'text/javascript');
-  scriptEl.setAttribute('src', `${platform}/cordova.js`);
+  scriptEl.setAttribute('src', `/${platform}/cordova.js`);
   document.body.appendChild(scriptEl);
 
   console.log(`Injected cordova.js of ${platform} platform.`);


### PR DESCRIPTION
If you are on a page that is not the root then the inject script makes loads cordova from relative to the page (ie `/page/ios/cordova.js` rather than the intended `/iod/cordova.js`