### PR TITLE
build webpack also for electron

### DIFF
--- a/src/webpackCompile.ts
+++ b/src/webpackCompile.ts
@@ -11,7 +11,7 @@ import { createConfig } from './utils/webpackHelpers';
 import { createArguments, getVersion } from './utils/yargsHelpers';
 
 module.exports = async (ctx: Context) => {
-  const platforms = ['browser', 'android', 'ios'] as const;
+  const platforms = ['browser', 'android', 'ios', 'electron'] as const;
   if (!platforms.some((platform) => ctx.opts.platforms && ctx.opts.platforms.includes(platform))) {
     return;
   }


### PR DESCRIPTION
currently, when we run "cordova run or build electron" will not build webpack build, so we need to do it manually!