### PR TITLE
fix: Use webpack host in content URL if specified and is valid IP address

### DIFF
--- a/src/utils/webpackHelpers.ts
+++ b/src/utils/webpackHelpers.ts
@@ -51,3 +51,21 @@ export async function createConfig<T>(
 
   return config;
 }
+
+function isIpAddress(address: string) {
+  var match = address.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  return (
+    match != null &&
+    parseInt(match[1], 10) <= 255 &&
+    parseInt(match[2], 10) <= 255 &&
+    parseInt(match[3], 10) <= 255 &&
+    parseInt(match[4], 10) <= 255
+  );
+}
+
+export function guessIpAddress(address: string) {
+  if (address !== '0.0.0.0' && isIpAddress(address)) {
+    return address;
+  }
+  return undefined;
+}

--- a/src/webpackServe.ts
+++ b/src/webpackServe.ts
@@ -15,7 +15,12 @@ import { choosePort, prepareUrls } from 'react-dev-utils/WebpackDevServerUtils';
 import { Context } from './types';
 // eslint-disable-next-line import/no-named-as-default
 import options from './options';
-import { defaultHost, defaultPort, createConfig } from './utils/webpackHelpers';
+import {
+  defaultHost,
+  defaultPort,
+  createConfig,
+  guessIpAddress,
+} from './utils/webpackHelpers';
 import { createArguments, getVersion } from './utils/yargsHelpers';
 import ConfigParser from './utils/ConfigParser';
 
@@ -154,7 +159,9 @@ module.exports = async (ctx: Context) => {
         const configXml = new ConfigParser(configXmlPath);
         configXml.setElement('content', {
           src: `${protocol}://${
-            urls.lanUrlForConfig || defaultAccessHost[platform]
+            guessIpAddress(host) ||
+            urls.lanUrlForConfig ||
+            defaultAccessHost[platform]
           }:${port}`,
         });
         if (platform === 'ios') {


### PR DESCRIPTION
If a host is specified, then the automatic address guess via prepareURL always returns undefined for the lanUrlForConfig.
This change allows the host to be embedded in the app if it is a valid IP address.
This allows overriding via config or CLI when automatic IP resolution fails.

This allows the issue seen in #161 to be addressed by passing `--webpack.host=<MACHINE IP ADDRESS>` to the command.